### PR TITLE
remove multiline, remove spell name from args

### DIFF
--- a/aliases/pcast.py
+++ b/aliases/pcast.py
@@ -1,9 +1,8 @@
-multiline
 <drac2>
 IDs = load_yaml(get_gvar("e808cf94-12fb-45c4-9fd1-dcaa0d39c841"))
 args = &ARGS&
-cArgs = "&*&"
 spN = "&1&"
+cArgs = ' '.join([f'"{x}"' if ' ' in x else str(x) for x in args[1:] ]) if args else ''
 ch = character()
 sb = character().spellbook
 spN.lower()
@@ -65,5 +64,5 @@ if (not scc) or ig:
     out[1] = out[1] + ft
 else:
     out[-1] = out[-1] + ft
-return f'\n{ctx.prefix}'.join(out)
+return f'{ctx.prefix}'.join(out)
 </drac2>

--- a/aliases/pcast_docs.md
+++ b/aliases/pcast_docs.md
@@ -1,4 +1,5 @@
-Casting works just the same as ``!cast``, including being able to take all the same arguments. Works with ``!prep`` by default. If you expended a spell slot, it pritns a second embed to show your spell slot counters for that level.
+Casting works just the same as ``!cast``, including being able to take all the same arguments. Works with ``!prep`` by default. If you expended a spell slot, it includes a field to show your spell slot counters for that level.
+This works regardless if you used ``-noprep`` when importing or updating your sheet.
 For for further information see ``!help cast`` and ``!help prep``.
 
 Commands:

--- a/aliases/pcast_docs.md
+++ b/aliases/pcast_docs.md
@@ -1,5 +1,12 @@
-Casting works just the same as ``!cast``, including being able to take all the same arguments. Works with ``!prep`` by default. If you expended a spell slot, it includes a field to show your spell slot counters for that level.
-This works regardless if you used ``-noprep`` when importing or updating your sheet.
+Cast spells according to what you have prepared with aliases like `` !prep`` by Derixyleth#0636. This collection works regardless if you used ``-noprep`` when importing or updating your sheet.
+
+Find the source code for the alias on [my github repo](https://github.com/ItsQc/Avrae-Projects)
+Photo credit: [Danika Anya](https://unsplash.com/@danika_anya)
+
+-----------
+
+Casting works just the same as ``!cast``, including being able to take all the same arguments and displaying your spell slot counters. Works with the popular ``!prep`` alias by default. If you expended a spell slot, it includes a field to show your spell slot counters for that level.
+This works regardless of using ``-noprep`` when importing or updating your sheet.
 For for further information see ``!help cast`` and ``!help prep``.
 
 Commands:


### PR DESCRIPTION
You don't need to use multiline when returning a single command using an alias, and I would avoid passing the spell name in the args when using `!cast` as it might activate user's snippets.  I provided alternatives to this but I didn't test it (I pulled the cArgs line from an alias of mine and removed multiline and \n before {ctx.prefix} )

So, best to test it first.

Signed-off-by: TheReverendB <75177105+TheReverendB@users.noreply.github.com>